### PR TITLE
Fix doc return values in gtrs() and wls()

### DIFF
--- a/autonav/GTRS.py
+++ b/autonav/GTRS.py
@@ -57,7 +57,7 @@ def gtrs(
 
     Returns:
         The estimated trajectory computed using the GTRS algorithm for the given input scenario
-        and the true trajectory that the UAV followed.
+          and the true trajectory that the UAV followed.
     """
     # Validate inputs
     if size(a_i, axis=1) != n:

--- a/autonav/WLS.py
+++ b/autonav/WLS.py
@@ -31,7 +31,7 @@ def wls(
 
     Returns:
         The estimated trajectory computed using the WLS algorithm for the given input scenario
-        and the true trajectory that the UAV followed.
+          and the true trajectory that the UAV followed.
     """
     # Validate inputs
     if size(a_i, axis=1) != n:


### PR DESCRIPTION
If you look at the current generated docs, you can see that the return values for both `wls()` and `gtrs()` have broken formatting. This small change fixes that.